### PR TITLE
ci(dependabot): fix dependabot access to github registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,13 @@
 
 version: 2
 
-updates:
+registries:
+  npm-github:
+    type: npm-registry
+    url: npm.pkg.github.com
+    token: ${{secrets.GH_REGISTRY_ACCESS_TOKEN}}
 
+updates:
   # Required options
   - package-ecosystem: npm
     directory: "/"


### PR DESCRIPTION
Allow dependabot to access to github registry