### PR TITLE
ci(dependabot): link registry for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ registries:
 updates:
   # Required options
   - package-ecosystem: npm
-    registries: npm-github
+    registries: "*"
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#registries